### PR TITLE
Never Trust User Input

### DIFF
--- a/app/controllers/proxy_controller.rb
+++ b/app/controllers/proxy_controller.rb
@@ -201,8 +201,7 @@ class ProxyController < ApplicationController
     end
 
     if current_user&.groups and not current_user&.groups.empty?
-      disraptor_groups = current_user.groups
-        .map{ |group| group.name }
+      disraptor_groups = Disraptor::GroupStore.translate_groups(current_user.groups)
       proxy_headers['x-disraptor-groups'] = disraptor_groups.join(',')
     end
 

--- a/lib/group_store.rb
+++ b/lib/group_store.rb
@@ -1,0 +1,39 @@
+class Disraptor::GroupStore
+  class << self
+    def get_groups
+      return PluginStore.get(Disraptor::PLUGIN_NAME, 'groups') || {}
+    end
+
+    def translate_groups(untrusted_groups)
+      ret = []
+      trusted_groups = get_groups()
+      
+      for group in untrusted_groups do
+        group_id = group.id
+        group_name = group.name
+        
+        if groups.key?(group_id)
+          # If you see a group for the second time: do not trust it (As a user might have changed this)
+          ret.append(groups[group_id])
+        else
+          # If you see a group for the first time: Trust it (As this is maintained by the system)
+          add_group(group_id, group_name)
+          ret.append(group_name)
+        end
+      end
+      
+      return ret
+
+    def add_group(group_id, group)
+      groups = get_groups()
+
+      if groups.key?(group_id):
+        return false
+      end
+      
+      groups[group_id] = group.name
+
+      return PluginStore.set(Disraptor::PLUGIN_NAME, 'groups', groups)
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -18,6 +18,8 @@ end
 load File.expand_path('../lib/route_store.rb', __FILE__)
 load File.expand_path('../app/models/route.rb', __FILE__)
 
+load File.expand_path('../lib/group_store.rb', __FILE__)
+
 after_initialize do
   load File.expand_path('../app/controllers/disraptor/routes_controller.rb', __FILE__)
   load File.expand_path('../app/controllers/proxy_controller.rb', __FILE__)


### PR DESCRIPTION
Neve trust user input: x-disraptor-groups should not show the names that the user has maybe modified

This will help to implement #24.